### PR TITLE
Add custom scope names

### DIFF
--- a/ESLZ/rbac.tfvars
+++ b/ESLZ/rbac.tfvars
@@ -1,6 +1,7 @@
 rbac = [
   {
     scope = ["ID of the resource you are trying to assign to"]
+    // custom_scope_names =  [ "Custom-Name" ]                  # (Optional) For each scope id above, a custom name within TF for naming the resource. Useful when it doesn't yet exist.
     role = "Storage Blob Data Contributor"                      # Can be either the name of the role or ID
     principal_id = ["xx"]                                       # Must be Object ID of the user, group, or service principal
   }

--- a/README.md
+++ b/README.md
@@ -38,3 +38,38 @@ module "rbac" {
 ```
 Please change variable in the for_each block to the variable in your module. \
 The block in the tfvars file will be the same as the one in the template
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_role_assignment.roles](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_custom_scope_names"></a> [custom\_scope\_names](#input\_custom\_scope\_names) | List of names to use instead of the scopes for naming TF resources. This is required if the scope is being created in the same TF invocation. | `list(string)` | `[]` | no |
+| <a name="input_principal_id"></a> [principal\_id](#input\_principal\_id) | ID for the principal (User, Group, Service Principal) to assign the Role definition to | `any` | n/a | yes |
+| <a name="input_role_assignment"></a> [role\_assignment](#input\_role\_assignment) | Object containing all the parameters for the role\_assignment | `any` | `{}` | no |
+| <a name="input_role_definition"></a> [role\_definition](#input\_role\_definition) | Name or ID of the RBAC role being assigned | `string` | n/a | yes |
+| <a name="input_scope"></a> [scope](#input\_scope) | ID sfor the resource where the role will be assigned | `list(string)` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/locals.tf
+++ b/locals.tf
@@ -1,8 +1,17 @@
 locals {
   role_definition_type =  strcontains(var.role_definition, "/roleDefinitions/") ? "id" : "name"
 
-  assignments = flatten([for id in var.principal_id: [for scope in var.scope: {
+  scope_ids_or_names = length(var.custom_scope_names) == length(var.scope) ? {
+                              for name in var.custom_scope_names : 
+                                name => var.scope[index(var.custom_scope_names, name)]
+                          } : {
+                            for scope in var.scope: scope => basename(scope)
+                          }
+
+
+  assignments = flatten([for id in var.principal_id: [for name, scope in local.scope_ids_or_names: {
     principal_id = id 
     scope = scope
+    scope_name = name
   }]])
 }

--- a/module.tf
+++ b/module.tf
@@ -1,5 +1,5 @@
 resource "azurerm_role_assignment" "roles" {
-  for_each = {for assignment in local.assignments: "${assignment.principal_id}-${basename(assignment.scope)}" => assignment}
+  for_each = {for assignment in local.assignments: "${assignment.principal_id}-${assignment.scope_name}" => assignment}
   scope = each.value.scope
   principal_id = each.value.principal_id
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,12 @@
 variable "scope" {
-  description = "ID for the resource where the role will be assigned"
-  type = any
+  description = "ID sfor the resource where the role will be assigned"
+  type = list(string)
+}
+
+variable "custom_scope_names" {
+  description = "List of names to use instead of the scopes for naming TF resources. This is required if the scope is being created in the same TF invocation."
+  type = list(string)
+  default = []
 }
 
 variable "principal_id" {


### PR DESCRIPTION
This allows defining the resources before the scope is created. Otherwise, using the id for naming caused an issue assigning roles to a scope that was in the same Terraform plan.